### PR TITLE
ci: add selene as a linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -123,4 +123,11 @@ repos:
     - repo: https://github.com/JohnnyMorganz/StyLua
       rev: v0.20.0
       hooks:
-        - id: stylua # or stylua-system / stylua-github
+        - id: stylua
+    - repo: local
+      hooks:
+        - id: selene
+          name: Selene Lint
+          language: system
+          entry: selene
+          files: \.lua$

--- a/selene.toml
+++ b/selene.toml
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: CC0-1.0
+
+std="vim"

--- a/vim.toml
+++ b/vim.toml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: CC0-1.0
+
+[selene]
+base = "lua51"
+name = "vim"
+
+[vim]
+any = true
+
+[[describe.args]]
+type = "string"
+[[describe.args]]
+type = "function"
+
+[[it.args]]
+type = "string"
+[[it.args]]
+type = "function"
+
+[[before_each.args]]
+type = "function"
+[[after_each.args]]
+type = "function"
+
+[assert.is_not]
+any = true
+
+[assert.matches]
+any = true
+
+[assert.has_error]
+any = true
+
+[[assert.equals.args]]
+type = "any"
+[[assert.equals.args]]
+type = "any"
+[[assert.equals.args]]
+type = "any"
+required = false
+
+[[assert.same.args]]
+type = "any"
+[[assert.same.args]]
+type = "any"
+
+[[assert.truthy.args]]
+type = "any"
+
+[[assert.falsy.args]]
+type = "any"
+
+[[assert.spy.args]]
+type = "any"
+
+[[assert.stub.args]]
+type = "any"


### PR DESCRIPTION
### TL;DR

Added Selene Lua linter to pre-commit hooks and configured it for Vim/Neovim development.

### What changed?

- Updated `.pre-commit-config.yaml` to include Selene as a local hook
- Added `selene.toml` configuration file to set the Vim standard
- Created `vim.toml` to define Vim-specific globals and functions for Selene

### How to test?

1. Install Selene: `cargo install selene`
2. Run pre-commit hooks: `pre-commit run --all-files`
3. Verify that Selene lints Lua files without errors
4. Make changes to Lua files and ensure Selene catches any issues

### Why make this change?

Integrating Selene as a Lua linter improves code quality and consistency in Vim/Neovim plugin development. It helps catch potential errors and enforces best practices specific to the Vim environment.