### PR TITLE
ci: update the pre-commit config to target lua files for selene

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -130,4 +130,6 @@ repos:
           name: Selene Lint
           language: system
           entry: selene
+          types:
+            - lua
           files: \.lua$


### PR DESCRIPTION
### TL;DR

Updated the Selene Lint pre-commit hook configuration to explicitly specify Lua file types.

### What changed?

Added `types: - lua` to the Selene Lint pre-commit hook configuration in the `.pre-commit-config.yaml` file. This explicitly defines the file types that the Selene linter should process.

### How to test?

1. Ensure you have the pre-commit hooks installed.
2. Make changes to a Lua file in the repository.
3. Run `pre-commit run --all-files` or attempt to commit the changes.
4. Verify that the Selene linter runs on the Lua files as expected.

### Why make this change?

This change improves the specificity of the Selene Lint pre-commit hook. By explicitly defining the file types, we ensure that the linter only runs on Lua files, potentially improving performance and reducing false positives on non-Lua files that might have a `.lua` extension.