### PR TITLE
docs: ensure newly generated docs are included

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -61,3 +61,11 @@ path = [
 precedence = "override"
 SPDX-FileCopyrightText = "2024 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"
+
+[[annotations]]
+path = [
+  "doc/*",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "2024 Ali Sajid Imami"
+SPDX-License-Identifier = "MIT"

--- a/doc/neovim-vivify-markdown.txt
+++ b/doc/neovim-vivify-markdown.txt
@@ -1,0 +1,46 @@
+==============================================================================
+------------------------------------------------------------------------------
+                                                 *NeovimVivifyMarkdown.toggle()*
+                        `NeovimVivifyMarkdown.toggle`()
+Toggle the plugin by calling the `enable`/`disable` methods respectively.
+
+------------------------------------------------------------------------------
+                                                 *NeovimVivifyMarkdown.enable()*
+                     `NeovimVivifyMarkdown.enable`({scope})
+Initializes the plugin, sets event listeners and internal state.
+
+------------------------------------------------------------------------------
+                                                *NeovimVivifyMarkdown.disable()*
+                        `NeovimVivifyMarkdown.disable`()
+Disables the plugin, clear highlight groups and autocmds, closes side buffers and resets the internal state.
+
+
+==============================================================================
+------------------------------------------------------------------------------
+                                                  *NeovimVivifyMarkdown.options*
+                         `NeovimVivifyMarkdown.options`
+NeovimVivifyMarkdown configuration with its default values.
+
+Type ~
+`(table)`
+Default values:
+>lua
+  NeovimVivifyMarkdown.options = {
+      -- Prints useful logs about what event are triggered, and reasons actions are executed.
+      debug = false,
+  }
+
+<
+------------------------------------------------------------------------------
+                                                  *NeovimVivifyMarkdown.setup()*
+                    `NeovimVivifyMarkdown.setup`({options})
+Define your  setup.
+
+Parameters ~
+{options} `(table)` Module config table. See |NeovimVivifyMarkdown.options|.
+
+Usage ~
+`require("").setup()` (add `{}` with your |NeovimVivifyMarkdown.options| table)
+
+
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,5 @@
+NeovimVivifyMarkdown.disable()  neovim-vivify-markdown.txt  /*NeovimVivifyMarkdown.disable()*
+NeovimVivifyMarkdown.enable()   neovim-vivify-markdown.txt  /*NeovimVivifyMarkdown.enable()*
+NeovimVivifyMarkdown.options    neovim-vivify-markdown.txt  /*NeovimVivifyMarkdown.options*
+NeovimVivifyMarkdown.setup()    neovim-vivify-markdown.txt  /*NeovimVivifyMarkdown.setup()*
+NeovimVivifyMarkdown.toggle()   neovim-vivify-markdown.txt  /*NeovimVivifyMarkdown.toggle()*


### PR DESCRIPTION
### TL;DR

Added documentation for the NeovimVivifyMarkdown plugin and updated the REUSE.toml file.

### What changed?

- Added a new documentation file `doc/neovim-vivify-markdown.txt` with detailed information about the NeovimVivifyMarkdown plugin's functions and options.
- Created a `doc/tags` file for easy navigation within the documentation.
- Updated the REUSE.toml file to include copyright and license information for the `doc/*` directory.

### How to test?

1. Open Neovim and navigate to the plugin's documentation using `:help NeovimVivifyMarkdown`.
2. Verify that the documentation is accessible and properly formatted.
3. Check that the tags are working by jumping to different sections using the tag links.
4. Ensure that the copyright and license information for the `doc/*` directory is correctly set in the REUSE.toml file.

### Why make this change?

This change improves the plugin's usability by providing comprehensive documentation for users. It also ensures proper licensing and copyright attribution for the documentation files, maintaining compliance with open-source best practices.