### PR TITLE
docs: add a `LICENSE` file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
### TL;DR

Added MIT License to the project.

### What changed?

- Created a new file named `LICENSE` in the root directory.
- Added the full text of the MIT License to the file.

### How to test?

1. Check that the `LICENSE` file exists in the root directory of the project.
2. Verify that the content of the file matches the standard MIT License text.
3. Ensure that the placeholders for `<year>` and `<copyright holders>` are present and ready to be filled with appropriate information.

### Why make this change?

Adding a license to the project is crucial for:
- Clearly defining the terms under which the software can be used, modified, and distributed.
- Protecting the rights of the copyright holders.
- Encouraging open-source collaboration by providing legal clarity for contributors and users.
- Aligning with best practices for open-source software development.