### PR TITLE
docs: update the badges in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ SPDX-License-Identifier: MIT
     Easily render markdown files in neovim
 </p>
 
-![License](https://img.shields.io/github/license/Imamiland/neovim-vivify-markdown.nvim)
-![Neovim Version](https://img.shields.io/badge/Neovim-0.8%20%7C%200.9%20%7C%20latest-blue)
-![CI](https://github.com/Imamiland/neovim-vivify-markdown.nvim/actions/workflows/ci.yml/badge.svg)
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/Imamiland/neovim-vivify-markdown.nvim)
+[![License](https://img.shields.io/github/license/Imamiland/neovim-vivify-markdown.nvim)](https://github.com/Imamiland/neovim-vivify-markdown.nvim/blob/main/LICENSE)
+![Neovim Version](https://img.shields.io/badge/Neovim-0.8%20%7C%200.9%20%7C%20stable-blue)
+[![Continuous Integration](https://github.com/Imamiland/neovim-vivify-markdown.nvim/actions/workflows/ci.yaml/badge.svg)](https://github.com/Imamiland/neovim-vivify-markdown.nvim/actions/workflows/ci.yaml)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/Imamiland/neovim-vivify-markdown.nvim)](https://github.com/Imamiland/neovim-vivify-markdown.nvim/releases/current)
 ![GitHub Repo stars](https://img.shields.io/github/stars/Imamiland/neovim-vivify-markdown.nvim)
 ![code style: stylua](https://img.shields.io/badge/code%20style-stylua-blue)
 [![REUSE status](https://api.reuse.software/badge/github.com/Imamiland/neovim-vivify-markdown.nvim)](https://api.reuse.software/info/github.com/Imamiland/neovim-vivify-markdown.nvim)


### PR DESCRIPTION
### TL;DR

Updated README badges with clickable links and improved version information.

### What changed?

- Added clickable links to the License, CI, and Release badges
- Updated Neovim version badge to show "stable" instead of "latest"
- Corrected the CI workflow filename in the badge URL

### How to test?

1. View the README.md file in the repository
2. Click on the License, CI, and Release badges to verify they lead to the correct pages
3. Confirm the Neovim version badge displays "stable" instead of "latest"

### Why make this change?

These updates improve the README's functionality and accuracy:
- Clickable badges provide easier access to important project information
- Using "stable" instead of "latest" for Neovim version is more precise
- Correcting the CI workflow filename ensures the badge displays the correct status